### PR TITLE
EK-117: Added workflow to call Netlify build hook

### DIFF
--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -1,0 +1,18 @@
+# .github/workflows/scheduled-build.yml
+
+# See https://community.netlify.com/t/scheduling-builds-and-deploys-with-netlify/2563/9
+
+name: Scheduled Netlify Build
+on:
+  schedule:
+    # Run at 8:50 AM UTC (3:50 AM or 4:50 AM ET) daily
+    - cron: '50 8 * * *'
+jobs:
+  build:
+    name: Request Netlify Webhook
+    runs-on: ubuntu-latest
+    steps:
+      - name: Curl request
+        env:
+          NETLIFY_BUILD_HOOK: ${{ secrets.NETLIFY_BUILD_HOOK }}
+        run: curl -X POST -d {} NETLIFY_BUILD_HOOK


### PR DESCRIPTION
`secrets.NETLIFY_BUILD_HOOK` refers to the secret stored at https://github.com/Stevens-EWS/faculty-profiles/settings/secrets -- github provides write access, but not read access, so trust that it has been populated with the URL of a build hook I created and named "Github Actions" seen at https://app.netlify.com/sites/stevens-fp/settings/deploys#build-hooks