### PR TITLE
Added build status badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # faculty-profiles
+[![Netlify Status](https://api.netlify.com/api/v1/badges/098d9409-d758-48bd-85d1-177bbdf9d3cb/deploy-status)](https://app.netlify.com/sites/stevens-fp/deploys)
+
 Faculty Profiles (Netlify)


### PR DESCRIPTION
This is basically for adding a status badge to our repo as an indication of the build status.
**Test:** check https://github.com/Stevens-EWS/faculty-profiles/tree/Adding-status-badge and confirm the status badge shows up and shows the latest build status.

**References:**
https://docs.netlify.com/monitor-sites/status-badges/
https://www.netlify.com/blog/2019/01/29/sharing-the-love-with-netlify-deployment-badges/