### PR TITLE
EK-416: Added logic to handle gifs and other images that cause childmageSharp to be null

### DIFF
--- a/gatsby_fp/netlify.toml
+++ b/gatsby_fp/netlify.toml
@@ -1,4 +1,2 @@
-[context.production.environment]
-    PEOPLEAPI_HOST = 'api.stevens.edu/people/faculty'
 [context.deploy-preview.environment]
-    PEOPLEAPI_HOST = 'api.stevens.edu/people-dev2/faculty'
+    PEOPLEAPI_HOST = 'api.stevens.edu/people/faculty'

--- a/gatsby_fp/src/components/Layout.js
+++ b/gatsby_fp/src/components/Layout.js
@@ -88,6 +88,7 @@ export const facultyData = graphql`
             ...GatsbyImageSharpFluid
           }
         }
+        publicURL
       }
       service_university {
         org

--- a/gatsby_fp/src/components/Layout/Body/Fields.js
+++ b/gatsby_fp/src/components/Layout/Body/Fields.js
@@ -32,6 +32,7 @@ export default function Fields({ facultyData }) {
         school={facultyData.school}
         department={facultyData.ses_department}
         email={facultyData.pf_email}
+        publicURL={facultyData.facultyImg.publicURL}
       />
       <div className="main_field_wrapper">
         {facultyData.education && (

--- a/gatsby_fp/src/components/Layout/Body/Fields.js
+++ b/gatsby_fp/src/components/Layout/Body/Fields.js
@@ -19,7 +19,7 @@ export default function Fields({ facultyData }) {
         room={facultyData.room}
         phone={facultyData.pf_work_phone}
         fax={facultyData.pf_work_fax}
-        fluidData={
+        imageFluidData={
           facultyData.facultyImg ? 
             (facultyData.facultyImg.childImageSharp ? 
               facultyData.facultyImg.childImageSharp.fluid : null) 
@@ -32,7 +32,7 @@ export default function Fields({ facultyData }) {
         school={facultyData.school}
         department={facultyData.ses_department}
         email={facultyData.pf_email}
-        publicURL={
+        imagePublicURL={
           facultyData.facultyImg ? 
             facultyData.facultyImg.publicURL
           : null

--- a/gatsby_fp/src/components/Layout/Body/Fields.js
+++ b/gatsby_fp/src/components/Layout/Body/Fields.js
@@ -32,7 +32,11 @@ export default function Fields({ facultyData }) {
         school={facultyData.school}
         department={facultyData.ses_department}
         email={facultyData.pf_email}
-        publicURL={facultyData.facultyImg.publicURL}
+        publicURL={
+          facultyData.facultyImg ? 
+            facultyData.facultyImg.publicURL
+          : null
+        }
       />
       <div className="main_field_wrapper">
         {facultyData.education && (

--- a/gatsby_fp/src/components/Layout/Body/Fields/GenInfoTable.js
+++ b/gatsby_fp/src/components/Layout/Body/Fields/GenInfoTable.js
@@ -13,7 +13,8 @@ export default function GenInfoTable({
   website,
   firstName,
   lastName,
-  email
+  email,
+  publicURL, // for gifs and when fluidData (childImageSharp) is null
 }) {
   return (
     <>
@@ -42,6 +43,18 @@ export default function GenInfoTable({
               fadeIn={false}
               placeholderStyle={{
                 visibility: "hidden"
+              }}
+            />
+          </div>
+        )}
+        {(!fluidData && publicURL) && (
+          <div className="img_wrapper">
+            <img
+              src={publicURL}
+              alt={`${firstName} ${lastName}`}
+              style={{
+                height: "auto",
+                width: "100%"
               }}
             />
           </div>

--- a/gatsby_fp/src/components/Layout/Body/Fields/GenInfoTable.js
+++ b/gatsby_fp/src/components/Layout/Body/Fields/GenInfoTable.js
@@ -5,7 +5,7 @@ export default function GenInfoTable({
   school,
   department,
   title,
-  fluidData,
+  imageFluidData,
   building,
   room,
   phone,
@@ -14,7 +14,7 @@ export default function GenInfoTable({
   firstName,
   lastName,
   email,
-  publicURL, // for gifs and when fluidData (childImageSharp) is null
+  imagePublicURL, // for gifs and when imageFluidData (childImageSharp) is null
 }) {
   return (
     <>
@@ -27,10 +27,10 @@ export default function GenInfoTable({
         </div>
       )} 
       <div className="flex_box">
-        {fluidData && (
+        {imageFluidData && (
           <div className="img_wrapper">
             <Img
-              fluid={fluidData}
+              fluid={imageFluidData}
               alt={`${firstName} ${lastName}`}
               style={{
                 display: "block",
@@ -47,10 +47,10 @@ export default function GenInfoTable({
             />
           </div>
         )}
-        {(!fluidData && publicURL) && (
+        {(!imageFluidData && imagePublicURL) && (
           <div className="img_wrapper">
             <img
-              src={publicURL}
+              src={imagePublicURL}
               alt={`${firstName} ${lastName}`}
               style={{
                 height: "auto",


### PR DESCRIPTION
Test:

1. Faculty members with gifs for a facultyImg now have their image displayed on their page.
2. The Gatsby Img component should still be used for almost every faculty member.  Only gifs should cause childImageSharp to be null which would result in this component not being used.
3. If childImageSharp is null, regardless of the image extension, then the publicURL should be used to display the image.
