### PR TITLE
EK-410: Stopped including pubs that have a status other than "published"

### DIFF
--- a/gatsby_fp/src/components/Layout.js
+++ b/gatsby_fp/src/components/Layout.js
@@ -125,8 +125,6 @@ export const facultyData = graphql`
         pubctyst
         issue
         dty_pub
-        dty_acc
-        dty_sub
         web_address
         intellcont_auth {
           mname

--- a/gatsby_fp/src/components/Layout/Body/Fields/IntellCont/SubHeading.js
+++ b/gatsby_fp/src/components/Layout/Body/Fields/IntellCont/SubHeading.js
@@ -42,7 +42,10 @@ export default function IntellCont({ intellContList, publicationType }) {
         }
      })
       if (element.dty_pub) {
-        liString += ` (${element.dty_pub}). `
+        liString += ` (${element.dty_pub})`
+      }
+      if(element.dty_pub || element.intellcont_auth) {
+        liString += `. `
       }
       if (element.title) {
         liString += `${element.title}`

--- a/gatsby_fp/src/components/Layout/Body/Fields/IntellCont/SubHeading.js
+++ b/gatsby_fp/src/components/Layout/Body/Fields/IntellCont/SubHeading.js
@@ -4,54 +4,26 @@ const shortid = require("shortid")
 // Component used for the subheadings under selected publications
 export default function IntellCont({ intellContList, publicationType }) {
   
-  // Sorts publications first by status, then by year published
-  function sortStatusAndYear(intellContList) {
+  // Omits any publications whose status is not "Published", and then sorts them by year published
+  function sortPublishedByYear(intellContList) {
     var pubIntellContList = []
-    var accIntellContList = []
-    var subIntellContList = []
-
     intellContList.forEach(element => {
-      switch (element.status) {
-        case "Published":
-          pubIntellContList.push(element)
-          break
-        case "Accepted":
-          accIntellContList.push(element)
-          break
-        case "Submitted":
-          subIntellContList.push(element)
-          break
-        default:
-          break
+      if(element.status === "Published") {
+        pubIntellContList.push(element)
       }
     })
-
-    pubIntellContList.sort(function (a, b) { return b.dty_pub - a.dty_pub })
-    accIntellContList.sort(function (a, b) { return b.dty_acc - a.dty_acc })
-    subIntellContList.sort(function (a, b) { return b.dty_sub - a.dty_sub })
-
-    const sortedIntellContList = pubIntellContList.concat(accIntellContList, subIntellContList)
-    return sortedIntellContList
+    return pubIntellContList.sort(function (a, b) { return b.dty_pub - a.dty_pub })
   }
 
-  const sortedIntellContList = sortStatusAndYear(intellContList)
+  const sortedPubIntellContList = sortPublishedByYear(intellContList)
 
   /* Creates a list that is ready to be mapped into <li> tags that
      omits elements without a contype/contypeother that don't equal 
      the publicationType which is the title of the subheading.
      Elements without a contype/contypeother get omitted entirely! */
   const liInnerHtmlList =
-    sortedIntellContList.filter(element => (element.contype === publicationType || element.contypeother === publicationType)).map(element => {
+    sortedPubIntellContList.filter(element => (element.contype === publicationType || element.contypeother === publicationType)).map(element => {
       let liString = ''
-      if (element.status) {
-        liString += `${element.status} `
-      }
-      if (element.contype && !element.contypeother) {
-        liString += `${element.contype} – `
-      }
-      if (element.contypeother) {
-        liString += `${element.contypeother} – `
-      }
       element.intellcont_auth.forEach((elem, index) => {
         if (elem.lname) {
           liString += `${elem.lname}`
@@ -69,17 +41,8 @@ export default function IntellCont({ intellContList, publicationType }) {
           liString += `; `
         }
      })
-      if (element.status === "Published" && element.dty_pub) {
-        liString += ` (${element.dty_pub})`
-      }
-      if (element.status === "Accepted" && element.dty_acc) {
-        liString += ` (${element.dty_acc})`
-      }
-      if (element.status === "Submitted" && element.dty_sub) {
-        liString += ` (${element.dty_sub})`
-      }
-      if(element.dty_pub || element.dty_acc || element.dty_sub || element.intellcont_auth){
-        liString += `. `
+      if (element.dty_pub) {
+        liString += ` (${element.dty_pub}). `
       }
       if (element.title) {
         liString += `${element.title}`


### PR DESCRIPTION
Test:

1. We only display publications that have been Published.  Submitted and accepted publications are no longer displayed.
2. The status, type, and dash at the beginning of each publication is no longer displayed.  It should start as `[elem.lname], [elem.fname.substr(0,1)]. ([elem.dty_pub]). ......`

Compare with production https://faculty.stevens.edu/oasan
This user has all 3 statuses currently being displayed.