### PR TITLE
EK-425: Added alt_publications and notable_publicatons fields

### DIFF
--- a/gatsby_fp/src/components/Layout.js
+++ b/gatsby_fp/src/components/Layout.js
@@ -132,6 +132,8 @@ export const facultyData = graphql`
           lname
         }
       }
+      alt_publications
+      notable_publications
     }
   }
 `

--- a/gatsby_fp/src/components/Layout/Body/Fields.js
+++ b/gatsby_fp/src/components/Layout/Body/Fields.js
@@ -105,8 +105,14 @@ export default function Fields({ facultyData }) {
             fieldData={facultyData.patent_invention}
           />
         )}
-        {facultyData.intellcont && (
+        {(facultyData.intellcont && !facultyData.alt_publications) && (
           <IntellCont intellContList={facultyData.intellcont} />
+        )}
+        {(facultyData.alt_publications && facultyData.notable_publications) && (
+          <GeneralSection
+            fieldLabel="Selected Publications"
+            fieldData={facultyData.notable_publications}
+          />
         )}
         {facultyData.notable_courses && (
           <GeneralSection


### PR DESCRIPTION
Testing:

I made a link for each case we should be testing and described each case with the boolean logic for each variable being accounted for.   

Case 1: `(alt_publications && notable_publications != undefined)`
GeneralSection component is rendered.
https://deploy-preview-45--stevens-fp.netlify.app/podonkor

Case 2: `(alt_publications && notable_publications != undefined && intellcont != undefined)`
GeneralSection component is still rendered despite intellcont being populated with data.
https://deploy-preview-45--stevens-fp.netlify.app/sbae4

Case 3: `(alt_publications && notable_publications == undefined && intellcont != undefined)`
No component is rendered because alt_publications is true and notable_publications is undefined.
https://deploy-preview-45--stevens-fp.netlify.app/rharari

Case 4: `(alt_publications == undefined && notable_publications == undefined && intellcont != undefined)`
Intellcont component is rendered because none of the new fields are populated, and the user has intellcont populated.
https://deploy-preview-45--stevens-fp.netlify.app/pakcora