### PR TITLE
EK-426: added a tag to allowed tags

### DIFF
--- a/gatsby_fp/src/components/Layout.js
+++ b/gatsby_fp/src/components/Layout.js
@@ -8,7 +8,7 @@ export default function Layout({ children, data }) {
   const sanitizeHtml = require("sanitize-html-react")
   function sanitizeMarkup(child) {
     return sanitizeHtml(child, {
-      allowedTags: ["p", "b", "i", "u", "sup", "sub", "br"],
+      allowedTags: ["p", "b", "i", "u", "sup", "sub", "br", "a"],
     })
   }
   function traverse(parent) {


### PR DESCRIPTION
Added "a" to list of allowed tags.  

Test: 
check the second list item at https://deploy-preview-46--stevens-fp.netlify.app/gprastac - "Google Scholar Link" should be an actual link now.  Note all of this selected publications data, for some reason, is under the field "grant contract", and that most of the instances with "Google Scholar Link" in this user's data do not actually have an enclosing "a" tag which is why you will see the second list item have the actual link and none of the others