### PR TITLE
EK-425: Added alt_publications and notable_publications fields to schema

### DIFF
--- a/gatsby_fp/gatsby-config.js
+++ b/gatsby_fp/gatsby-config.js
@@ -37,6 +37,8 @@ module.exports = {
             notable_courses: String
             school: String
             ses_department: String
+            alt_publications: String
+            notable_publications: String
             service_university: [service_university]
             service_professional: [service_professional]
             education: [education]


### PR DESCRIPTION
Test: 
Gatsby builds successfully without the presence of these two fields in any node coming back from the people api.